### PR TITLE
Fix pd.concat not accepting the axis as positional argument

### DIFF
--- a/wym/FeatureContribution.py
+++ b/wym/FeatureContribution.py
@@ -149,7 +149,7 @@ class FeatureContribution(FeatureContributionGeneral):
         tmp_stat.columns = tmp_stat.columns + f'_allattr'
         stat_list.append(tmp_stat)
         joined_df = word_pairs_df[['id']].join(stat_list).fillna(null_value)
-        return joined_df.drop('id', 1)
+        return joined_df.drop('id', axis=1)
 
     @staticmethod
     def cycle_features(df_stat_suffix_list, features, rs_col='pred', use_softmax='proportional'):
@@ -240,7 +240,7 @@ class FeatureContribution(FeatureContributionGeneral):
         unpaired_stat.columns += '_unpaired'
         FeatureContribution.cycle_features([[com_df, paired_stat, '_paired'], [non_com_df, unpaired_stat, '_unpaired']],
                                            features=function_names)
-        contribution_df = pd.concat([com_df, non_com_df], 0).sort_index().fillna(0)
+        contribution_df = pd.concat([com_df, non_com_df], axis=0).sort_index().fillna(0)
 
         stat = FeatureContribution().compute_derived_features(contribution_df, function_names, possible_unpaired=[''],
                                                               additive_only=additive_only)

--- a/wym/FeatureExtractor.py
+++ b/wym/FeatureExtractor.py
@@ -89,7 +89,7 @@ class FeatureExtractor(FeatureExtractorGeneral):
         # all_stat.columns = all_stat.columns + f'_allattr'
         # return pd.concat([tmp_stat, all_stat], 1).fillna(null_value)
 
-        return pd.concat(stat_list, 1).fillna(null_value).sort_index()
+        return pd.concat(stat_list, axis=1).fillna(null_value).sort_index()
 
     @staticmethod
     def extract_features_simplified(word_pairs_df: pd.DataFrame, complementary=True, pos_threshold=.5, null_value=0,

--- a/wym/WordPairGenerator.py
+++ b/wym/WordPairGenerator.py
@@ -6,8 +6,10 @@ import numpy as np
 import pandas as pd
 import torch
 from tqdm.autonotebook import tqdm
-from .StableMarriage import gale_shapley
+from typing import List
 
+from .StableMarriage import gale_shapley
+from nltk.metrics.distance import jaro_winkler_similarity
 
 class EMFeatures:
     def __init__(self, df, exclude_attrs=('id', 'left_id', 'right_id', 'label'), device='cuda', n_proc=1):
@@ -32,7 +34,7 @@ class WordPairGenerator(EMFeatures):
                        'right_attribute': []}
     unpair_threshold = 0.6
     cross_attr_threshold = .65
-    duplicate_threshold = .75 #.85 #1.1  # .75 #TODO adjust duplicate threshold
+    duplicate_threshold = .75  # .85 #1.1  # .75 #TODO adjust duplicate threshold
 
     def __init__(self, words=None, embeddings=None, words_divided=None, use_schema=True, sentence_embedding_dict=None,
                  unpair_threshold=None, cross_attr_threshold=None, duplicate_threshold=None,
@@ -95,7 +97,6 @@ class WordPairGenerator(EMFeatures):
             tmp_word['id'] = [el.id.values[0]] * n_pairs
             word_dict_list.append(tmp_word)
             embedding_list.append(tmp_emb)
-
 
         keys = word_dict_list[0].keys()
         ret_dict = {key: np.concatenate([x[key] for x in word_dict_list]) for key in keys}
@@ -473,7 +474,7 @@ class WordPairGenerator(EMFeatures):
                     word_pair[key] = np.concatenate(
                         [word_pair[key], np.array(tmp_word_pairs[key])[side_mask].flatten()])
                     # display(word_pair[key], '***',np.concatenate([word_pair[key], np.array(tmp_word_pairs[key])[side_mask]]))
-                if len(pairs) >0:
+                if len(pairs) > 0:
                     all_attr = [pos_to_attr_map[pos] for pos in pairs[side_mask][:, 1 if all_side == 'right' else 0]]
                     word_pair[all_side + '_attribute'] = np.concatenate([word_pair[all_side + '_attribute'], all_attr])
                     unp_attr = np.array(unpaired_words[unp_side + '_attribute'])[
@@ -500,7 +501,7 @@ class WordPairGenerator(EMFeatures):
             return word_pair, emb_pair
 
     @staticmethod
-    def map_word_to_attr(df, cols, prefix='', verbose=False):
+    def map_word_to_attr(df: pd.DataFrame, cols: List[str], prefix: str = '', verbose: bool = False) -> List[dict]:
         tmp_res = []
 
         if verbose:
@@ -518,7 +519,6 @@ class WordPairGenerator(EMFeatures):
         return tmp_res
 
 
-from nltk.metrics.distance import jaro_winkler_similarity
 class WordPairGeneratorEdit(WordPairGenerator):
 
     def __init__(self, *args, **kwargs):

--- a/wym/wym.py
+++ b/wym/wym.py
@@ -57,10 +57,10 @@ class Wym:
         self.we = WordEmbedding(device=self.device, verbose=True, model_path=we_finetune_path)
         self.feature_extractor = FeatureExtractor()
 
-    def spilt_X_y(self, df, label_column_name='label'):
+    def split_x_y(self, df, label_column_name='label'):
         return df[self.columns_to_use], df[label_column_name]
 
-    def get_processed_data(self, df, batch_size=None, verbose=False):
+    def get_processed_data(self, df: pd.DataFrame, batch_size: int = None, verbose: bool = False):
         if hasattr(self, 'batch_size'):
             batch_size = self.batch_size
         we = self.we


### PR DESCRIPTION
Major change: adds the keyword argument "axis" to pd.concat as newer versions of pandas do not support it as positional argument, causing the script to raise a ValueError.
Minor changes: adds some type hints, reformats the code a little, and refactors the function "split_x_y" with a typo in its name.